### PR TITLE
A more helpful error message for missing simulators

### DIFF
--- a/lib/fourflusher/find.rb
+++ b/lib/fourflusher/find.rb
@@ -82,7 +82,10 @@ module Fourflusher
 
       oses = sims.map(&:os_name).uniq
       os = os.downcase.to_sym
-      fail "Invalid OS `#{os}`, valid values are #{oses.join(', ')}" unless oses.include?(os)
+
+      unless oses.include?(os)
+        fail "Invalid OS `#{os}`, valid values are #{oses.join(', ')}. Make sure you have at least one #{os} simulator installed."
+      end
 
       return sims if filter.nil?
       minimum_version = Gem::Version.new(minimum_version)

--- a/lib/fourflusher/find.rb
+++ b/lib/fourflusher/find.rb
@@ -84,7 +84,9 @@ module Fourflusher
       os = os.downcase.to_sym
 
       unless oses.include?(os)
-        fail "Invalid OS `#{os}`, valid values are #{oses.join(', ')}. Make sure you have at least one #{os} simulator installed."
+        fail "Invalid OS `#{os}`, valid values are #{oses.join(', ')}. Open Xcode "\
+          "and go to Window -> Devices to make sure you have at least one `#{os}` simulator set up. "\
+          "You can create a new simulator by pressing '+' in the bottom left corner of that window."
       end
 
       return sims if filter.nil?

--- a/lib/fourflusher/find.rb
+++ b/lib/fourflusher/find.rb
@@ -84,9 +84,8 @@ module Fourflusher
       os = os.downcase.to_sym
 
       unless oses.include?(os)
-        fail "Invalid OS `#{os}`, valid values are #{oses.join(', ')}. Open Xcode "\
-          "and go to Window -> Devices to make sure you have at least one `#{os}` simulator set up. "\
-          "You can create a new simulator by pressing '+' in the bottom left corner of that window."
+        fail "Could not find a `#{os}` simulator (valid values: #{oses.join(', ')}). Ensure that "\
+          "Xcode -> Window -> Devices has at least one `#{os}` simulator listed or otherwise add one."
       end
 
       return sims if filter.nil?


### PR DESCRIPTION
This vague error message caused me a lot of pain in CocoaPods/CocoaPods#5878. I thought it was an `xcodebuild` error, while in fact it was a very simple thing to fix. This should spare future generations from this failure mode.