### PR TITLE
Change stream processing to wait for threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 
 ##### Bug Fixes
 
-* Fixed crash with very long devices list/slow computers. [Martin Fiebig](https://github.com/mfiebig) [#17](https://github.com/CocoaPods/fourflusher/issues/17)
+* Fixed crash with very long devices list/slow computers.  
+  [Martin Fiebig](https://github.com/mfiebig)
+  [#17](https://github.com/CocoaPods/fourflusher/issues/17)
 
 
 ## 2.2.0 (2019-01-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ##### Bug Fixes
 
-* None.  
+* Fixed crash with very long devices list/slow computers. [Martin Fiebig](https://github.com/mfiebig) [#17](https://github.com/CocoaPods/fourflusher/issues/17)
 
 
 ## 2.2.0 (2019-01-28)

--- a/lib/fourflusher/executable.rb
+++ b/lib/fourflusher/executable.rb
@@ -162,15 +162,18 @@ module Fourflusher
     def self.popen3(bin, command, stdout, stderr)
       require 'open3'
       Open3.popen3(bin, *command) do |i, o, e, t|
-        reader(o, stdout)
-        reader(e, stderr)
+        stdout_thread = reader(o, stdout)
+        stderr_thread = reader(e, stderr)
         i.close
 
         status = t.value
 
         o.flush
         e.flush
-        sleep(0.01)
+
+        # wait for both threads to process the streams
+        stdout_thread.join
+        stderr_thread.join
 
         status
       end


### PR DESCRIPTION
This should fix #17 

The error was reliably reproducable by removing `executable.rb:173` (`sleep(0.01)`). It looks like the sleep was there to get the threads to finish. The replacement with `Thread.join` should reliably wait for both threads to process the streams.

I'm no expert concerning ruby, but at least the fix looks reasonable to me. Please tell me if I can improve it further (I tried to write a test for this, but failed to replace `Open3.popen3` within the `self.popen3` method.) :)